### PR TITLE
Facilitando o teste local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ O tipo pode ser: artigo, tutorial, dica, livro, vídeo, screencast,código etc
 
 Antes de enviar o pull request para o nosso repositório central, recomendamos testar a execução do site no seu computador. Isso pode ser feito através de um servidor web simples, como o `http-server` provido pelo `node`. Para isso, é preciso instalar o `node` e `npm` no seu sistema operacional, o que pode ser facilmente feito através do [site oficial](https://nodejs.org/en/) para Windows, ou através do `sudo apt-get install npm` no linux (debian). 
 
-Após instalar o `node` e o `npm`, instale o `http-server` através do comando `npm install -g http-server`, e após a instalação, navegue até o diretório `awesome-br.github.io` e execute o comando `http-server`.
+Após instalar o `node` e o `npm`, instale o `http-server` através do comando `npm install -g http-server`, e após a instalação, navegue até o diretório `awesome-br.github.io` e execute o comando `npm run http-server`.
 
 A resposta que terá é algo semelhante a:
 

--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ O formato para um novo item em qualquer tecnologia é:
       "url": "Url do site do autor"
     }
   }
-``` 
+```
 O tipo pode ser: artigo, tutorial, dica, livro, vídeo, screencast,código etc
 
 ## Como testar o awesome no seu computador
 
-Antes de enviar o pull request para o nosso repositório central, recomendamos testar a execução do site no seu computador. Isso pode ser feito através de um servidor web simples, como o `http-server` provido pelo `node`. Para isso, é preciso instalar o `node` e `npm` no seu sistema operacional, o que pode ser facilmente feito através do [site oficial](https://nodejs.org/en/) para Windows, ou através do `sudo apt-get install npm` no linux (debian). 
+Antes de enviar o pull request para o nosso repositório central, recomendamos testar a execução do site no seu computador. Isso pode ser feito através de um servidor web simples, como o `http-server` provido pelo `node`. Para isso, é preciso instalar o `node` e `npm` no seu sistema operacional, o que pode ser facilmente feito através do [site oficial](https://nodejs.org/en/) para Windows, ou através do `sudo apt-get install npm` no linux (debian).
 
-Após instalar o `node` e o `npm`, instale o `http-server` através do comando `npm install -g http-server`, e após a instalação, navegue até o diretório `awesome-br.github.io` e execute o comando `npm run http-server`.
+Após instalar o `node` e o `npm`, instale as dependências (`http-server`) através do comando `npm install`, e, após a instalação, execute o comando `npm run http-server`.
 
 A resposta que terá é algo semelhante a:
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ O tipo pode ser: artigo, tutorial, dica, livro, vídeo, screencast,código etc
 
 Antes de enviar o pull request para o nosso repositório central, recomendamos testar a execução do site no seu computador. Isso pode ser feito através de um servidor web simples, como o `http-server` provido pelo `node`. Para isso, é preciso instalar o `node` e `npm` no seu sistema operacional, o que pode ser facilmente feito através do [site oficial](https://nodejs.org/en/) para Windows, ou através do `sudo apt-get install npm` no linux (debian).
 
-Após instalar o `node` e o `npm`, instale as dependências (`http-server`) através do comando `npm install`, e, após a instalação, execute o comando `http-server`.
+Após instalar o `node` e o `npm`, instale as dependências (`http-server`) através do comando `npm install`, e, após a instalação, execute o comando `npm run http-server`.
 
 A resposta que terá é algo semelhante a:
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ O tipo pode ser: artigo, tutorial, dica, livro, vídeo, screencast,código etc
 
 Antes de enviar o pull request para o nosso repositório central, recomendamos testar a execução do site no seu computador. Isso pode ser feito através de um servidor web simples, como o `http-server` provido pelo `node`. Para isso, é preciso instalar o `node` e `npm` no seu sistema operacional, o que pode ser facilmente feito através do [site oficial](https://nodejs.org/en/) para Windows, ou através do `sudo apt-get install npm` no linux (debian).
 
-Após instalar o `node` e o `npm`, instale as dependências (`http-server`) através do comando `npm install`, e, após a instalação, execute o comando `npm run http-server`.
+Após instalar o `node` e o `npm`, instale as dependências (`http-server`) através do comando `npm install`, e, após a instalação, execute o comando `http-server`.
 
 A resposta que terá é algo semelhante a:
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "Awesome BR possui um formato aberto a comunidade que deseja compartilhar conteúdo de qualidade frente às tecnologias mais atuais do mercado.",
   "main": "",
+  "scripts": {
+    "http-server": "node_modules/http-server/bin/http-server"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/awesome-br/awesome-br.github.io.git"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Awesome BR possui um formato aberto a comunidade que deseja compartilhar conteúdo de qualidade frente às tecnologias mais atuais do mercado.",
   "main": "",
   "scripts": {
-    "preinstall": "npm install -g http-server"
+    "http-server": "node_modules/http-server/bin/http-server"
   },
   "repository": {
     "type": "git",
@@ -15,5 +15,8 @@
   "bugs": {
     "url": "https://github.com/awesome-br/awesome-br.github.io/issues"
   },
-  "homepage": "https://github.com/awesome-br/awesome-br.github.io#readme"
+  "homepage": "https://github.com/awesome-br/awesome-br.github.io#readme",
+  "dependencies": {
+    "http-server": "^0.8.5"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "awesome-br.github.io",
+  "version": "1.0.0",
+  "description": "Awesome BR possui um formato aberto a comunidade que deseja compartilhar conteúdo de qualidade frente às tecnologias mais atuais do mercado.",
+  "main": "",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/awesome-br/awesome-br.github.io.git"
+  },
+  "author": "awesome-br",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/awesome-br/awesome-br.github.io/issues"
+  },
+  "homepage": "https://github.com/awesome-br/awesome-br.github.io#readme",
+  "dependencies": {
+    "http-server": "^0.8.5"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Awesome BR possui um formato aberto a comunidade que deseja compartilhar conteúdo de qualidade frente às tecnologias mais atuais do mercado.",
   "main": "",
   "scripts": {
-    "http-server": "node_modules/http-server/bin/http-server"
+    "preinstall": "npm install -g http-server"
   },
   "repository": {
     "type": "git",
@@ -15,8 +15,5 @@
   "bugs": {
     "url": "https://github.com/awesome-br/awesome-br.github.io/issues"
   },
-  "homepage": "https://github.com/awesome-br/awesome-br.github.io#readme",
-  "dependencies": {
-    "http-server": "^0.8.5"
-  }
+  "homepage": "https://github.com/awesome-br/awesome-br.github.io#readme"
 }


### PR DESCRIPTION
Pra facilitar pro pessoal rodar localmente, adicionei a dependência `http-server` num `package.json`. 

A proposta é deixar mais simples o processo e evitar a instalação do módulo `http-server` globalmente.

O `.gitignore` foi adicionado e coloquei a `node_modules` pra evitar o versionamento dessa pasta.
