### PR TITLE
Added GitHub Student Developer Pack

### DIFF
--- a/sections/git.json
+++ b/sections/git.json
@@ -212,4 +212,25 @@
     "name": "Glauco Custódio",
     "url": "http://glaucocustodio.com/"
   }
+}, {
+  "name": "Pacote para desenvolvedor estudante - GitHub",
+  "url": "https://education.github.com/pack",
+  "type": "pacote",
+  "paid": false,
+  "tags": [
+    "git",
+    "aws",
+    "CrowdFlower",
+    "DigitalOcean",
+    "Microsoft Azure",
+    "Travis CI",
+    "udacity",
+    "Unreal Engine",
+    "bitnami",
+    "dnSimple"
+  ],
+  "author": {
+    "name": "Celio Rodrigues",
+    "url": "http://github.com/theSkilled"
+  }
 }]


### PR DESCRIPTION
Link muito útil pro pessoal que usa o gitHub, eles oferecem repositórios privados grátis por 2 anos, UnrealEngine full grátis e desconto e várias outras ferramentas.
