### PR TITLE
[AngularJS] Removido referência com link quebrado

### DIFF
--- a/sections/angular.json
+++ b/sections/angular.json
@@ -23,20 +23,6 @@
       "name": "DAVI FERREIRA ",
       "url": "http://www.daviferreira.com/blog"
     }
-  },
-
-  {
-    "name": "Guia Definitivo para Aprender AngularJS em Um Dia",
-    "url": "http://javascriptbrasil.com/2013/10/18/guia-definitivo-para-aprender-angularjs-em-um-dia/",
-    "type": "artigo",
-    "tags": [
-      "introdução",
-      "aplicação"
-    ],
-    "author": {
-      "name": "Eric Oliveira",
-      "url": "http://javascriptbrasil.com/author/eric-oliveira/"
-    }
   }, {
     "name": "Melhores práticas no uso do AngularJS",
     "url": "https://www.youtube.com/watch?v=yeaXSGbyYwo",


### PR DESCRIPTION
Artigo "[Guia definitivo para aprender AngularJS em um dia](http://javascriptbrasil.com/2013/10/18/guia-definitivo-para-aprender-angularjs-em-um-dia/)" está com o domínio vendido/quebrado.
